### PR TITLE
Remove bgzf_flush

### DIFF
--- a/main_dfit.cpp
+++ b/main_dfit.cpp
@@ -892,7 +892,6 @@ int main_dfit(int argc, char **argv) {
       exit(1);
     }
     kstr->l = 0;
-    bgzf_flush(fpfpfp);//<- is flush needed?
     bgzf_close(fpfpfp);
     
     
@@ -902,7 +901,6 @@ int main_dfit(int argc, char **argv) {
         exit(1);
       }
       bootkstr->l = 0;
-      bgzf_flush(bootfp);//<- is flush needed?
       bgzf_close(bootfp);
     }
     


### PR DESCRIPTION
Remove unnecessary `bgzf_flush`, since it is already called in [bgzf_close](https://nvlabs.github.io/nvbio/bgzf_8c_source.html#l00765) and triggers a warning:
```
main_dfit.cpp: In function 'int main_dfit(int, char**)':
main_dfit.cpp:895:15: warning: ignoring return value of 'int bgzf_flush(BGZF*)' declared with attribute 'warn_unused_result' [-Wunused-result]
  895 |     bgzf_flush(fpfpfp);//<- is flush needed?
      |     ~~~~~~~~~~^~~~~~~~
main_dfit.cpp:905:17: warning: ignoring return value of 'int bgzf_flush(BGZF*)' declared with attribute 'warn_unused_result' [-Wunused-result]
  905 |       bgzf_flush(bootfp);//<- is flush needed?
      |       ~~~~~~~~~~^~~~~~~~
```